### PR TITLE
Backport known CVEs to 8.6.0

### DIFF
--- a/SOURCES/CVE-2024-2004.patch
+++ b/SOURCES/CVE-2024-2004.patch
@@ -1,0 +1,138 @@
+From 74f1f2e0806a214797112783665d2e2227487854 Mon Sep 17 00:00:00 2001
+From: Daniel Gustafsson <daniel@yesql.se>
+Date: Tue, 27 Feb 2024 15:43:56 +0100
+Subject: [PATCH] setopt: Fix disabling all protocols
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+When disabling all protocols without enabling any, the resulting
+set of allowed protocols remained the default set.  Clearing the
+allowed set before inspecting the passed value from --proto make
+the set empty even in the errorpath of no protocols enabled.
+
+Co-authored-by: Dan Fandrich <dan@telarity.com>
+Reported-by: Dan Fandrich <dan@telarity.com>
+Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+Closes: #13004
+---
+ lib/setopt.c            | 16 ++++++++--------
+ tests/data/Makefile.inc |  2 +-
+ tests/data/test1474     | 42 +++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 51 insertions(+), 9 deletions(-)
+ create mode 100644 tests/data/test1474
+
+diff --git a/lib/setopt.c b/lib/setopt.c
+index a527077..3891eb6 100644
+--- a/lib/setopt.c
++++ b/lib/setopt.c
+@@ -155,6 +155,12 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
+ 
+ static CURLcode protocol2num(const char *str, curl_prot_t *val)
+ {
++  /*
++   * We are asked to cherry-pick protocols, so play it safe and disallow all
++   * protocols to start with, and re-add the wanted ones back in.
++   */
++  *val = 0;
++
+   if(!str)
+     return CURLE_BAD_FUNCTION_ARGUMENT;
+ 
+@@ -163,8 +169,6 @@ static CURLcode protocol2num(const char *str, curl_prot_t *val)
+     return CURLE_OK;
+   }
+ 
+-  *val = 0;
+-
+   do {
+     const char *token = str;
+     size_t tlen;
+@@ -2657,22 +2661,18 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+     break;
+ 
+   case CURLOPT_PROTOCOLS_STR: {
+-    curl_prot_t prot;
+     argptr = va_arg(param, char *);
+-    result = protocol2num(argptr, &prot);
++    result = protocol2num(argptr, &data->set.allowed_protocols);
+     if(result)
+       return result;
+-    data->set.allowed_protocols = prot;
+     break;
+   }
+ 
+   case CURLOPT_REDIR_PROTOCOLS_STR: {
+-    curl_prot_t prot;
+     argptr = va_arg(param, char *);
+-    result = protocol2num(argptr, &prot);
++    result = protocol2num(argptr, &data->set.redir_protocols);
+     if(result)
+       return result;
+-    data->set.redir_protocols = prot;
+     break;
+   }
+ 
+diff --git a/tests/data/Makefile.inc b/tests/data/Makefile.inc
+index 09d5c49..9b0e808 100644
+--- a/tests/data/Makefile.inc
++++ b/tests/data/Makefile.inc
+@@ -186,7 +186,7 @@ test1439 test1440 test1441 test1442 test1443 test1444 test1445 test1446 \
+ test1447 test1448 test1449 test1450 test1451 test1452 test1453 test1454 \
+ test1455 test1456 test1457 test1458 test1459 test1460 test1461 test1462 \
+ test1463 test1464 test1465 test1466 test1467 test1468 test1469 test1470 \
+-test1471 test1472 test1473          test1475 test1476 test1477 test1478 \
++test1471 test1472 test1473 test1474 test1475 test1476 test1477 test1478 \
+ \
+ test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
+ test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \
+diff --git a/tests/data/test1474 b/tests/data/test1474
+new file mode 100644
+index 0000000..c66fa28
+--- /dev/null
++++ b/tests/data/test1474
+@@ -0,0 +1,42 @@
++<testcase>
++<info>
++<keywords>
++HTTP
++HTTP GET
++--proto
++</keywords>
++</info>
++
++#
++# Server-side
++<reply>
++<data>
++</data>
++</reply>
++
++#
++# Client-side
++<client>
++<server>
++none
++</server>
++<features>
++http
++</features>
++<name>
++--proto -all disables all protocols
++</name>
++<command>
++--proto -all http://%HOSTIP:%NOLISTENPORT/%TESTNUMBER
++</command>
++</client>
++
++#
++# Verify data after the test has been "shot"
++<verify>
++# 1 - Protocol "http" disabled
++<errorcode>
++1
++</errorcode>
++</verify>
++</testcase>
+-- 
+2.43.0
+

--- a/SOURCES/CVE-2024-2379.patch
+++ b/SOURCES/CVE-2024-2379.patch
@@ -1,0 +1,52 @@
+From 887d227b5c8c78219486c5b090656ec54a08ebca Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 11 Mar 2024 10:53:08 +0100
+Subject: [PATCH] vquic-tls: return appropirate errors on wolfSSL errors
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Reported-by: Dexter Gerig
+Closes #13107
+---
+ lib/vquic/vquic-tls.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/vquic/vquic-tls.c b/lib/vquic/vquic-tls.c
+index cc7794e..dbde21f 100644
+--- a/lib/vquic/vquic-tls.c
++++ b/lib/vquic/vquic-tls.c
+@@ -375,6 +375,7 @@ static CURLcode curl_wssl_init_ctx(struct quic_tls_ctx *ctx,
+     char error_buffer[256];
+     ERR_error_string_n(ERR_get_error(), error_buffer, sizeof(error_buffer));
+     failf(data, "wolfSSL failed to set ciphers: %s", error_buffer);
++    result = CURLE_BAD_FUNCTION_ARGUMENT;
+     goto out;
+   }
+ 
+@@ -382,6 +383,7 @@ static CURLcode curl_wssl_init_ctx(struct quic_tls_ctx *ctx,
+                                   conn_config->curves :
+                                   (char *)QUIC_GROUPS) != 1) {
+     failf(data, "wolfSSL failed to set curves");
++    result = CURLE_BAD_FUNCTION_ARGUMENT;
+     goto out;
+   }
+ 
+@@ -392,6 +394,7 @@ static CURLcode curl_wssl_init_ctx(struct quic_tls_ctx *ctx,
+     wolfSSL_CTX_set_keylog_callback(ctx->ssl_ctx, keylog_callback);
+ #else
+     failf(data, "wolfSSL was built without keylog callback");
++    result = CURLE_NOT_BUILT_IN;
+     goto out;
+ #endif
+   }
+@@ -414,6 +417,7 @@ static CURLcode curl_wssl_init_ctx(struct quic_tls_ctx *ctx,
+               "  CAfile: %s CApath: %s",
+               ssl_cafile ? ssl_cafile : "none",
+               ssl_capath ? ssl_capath : "none");
++        result = CURLE_SSL_CACERT;
+         goto out;
+       }
+       infof(data, " CAfile: %s", ssl_cafile ? ssl_cafile : "none");
+-- 
+2.43.0
+

--- a/SOURCES/CVE-2024-2398.patch
+++ b/SOURCES/CVE-2024-2398.patch
@@ -1,0 +1,94 @@
+From d19498b263bc68fa06a6c500b6f2d7956168dbd3 Mon Sep 17 00:00:00 2001
+From: Stefan Eissing <stefan@eissing.org>
+Date: Wed, 6 Mar 2024 09:36:08 +0100
+Subject: [PATCH] http2: push headers better cleanup
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+- provide common cleanup method for push headers
+
+Closes #13054
+---
+ lib/http2.c | 34 +++++++++++++++-------------------
+ 1 file changed, 15 insertions(+), 19 deletions(-)
+
+diff --git a/lib/http2.c b/lib/http2.c
+index c3157d1..28562d8 100644
+--- a/lib/http2.c
++++ b/lib/http2.c
+@@ -271,6 +271,15 @@ static CURLcode http2_data_setup(struct Curl_cfilter *cf,
+   return CURLE_OK;
+ }
+ 
++static void free_push_headers(struct h2_stream_ctx *stream)
++{
++  size_t i;
++  for(i = 0; i<stream->push_headers_used; i++)
++    free(stream->push_headers[i]);
++  Curl_safefree(stream->push_headers);
++  stream->push_headers_used = 0;
++}
++
+ static void http2_data_done(struct Curl_cfilter *cf,
+                             struct Curl_easy *data, bool premature)
+ {
+@@ -317,15 +326,7 @@ static void http2_data_done(struct Curl_cfilter *cf,
+   Curl_bufq_free(&stream->recvbuf);
+   Curl_h1_req_parse_free(&stream->h1);
+   Curl_dynhds_free(&stream->resp_trailers);
+-  if(stream->push_headers) {
+-    /* if they weren't used and then freed before */
+-    for(; stream->push_headers_used > 0; --stream->push_headers_used) {
+-      free(stream->push_headers[stream->push_headers_used - 1]);
+-    }
+-    free(stream->push_headers);
+-    stream->push_headers = NULL;
+-  }
+-
++  free_push_headers(stream);
+   free(stream);
+   H2_STREAM_LCTX(data) = NULL;
+ }
+@@ -872,7 +873,6 @@ static int push_promise(struct Curl_cfilter *cf,
+     struct curl_pushheaders heads;
+     CURLMcode rc;
+     CURLcode result;
+-    size_t i;
+     /* clone the parent */
+     struct Curl_easy *newhandle = h2_duphandle(cf, data);
+     if(!newhandle) {
+@@ -917,11 +917,7 @@ static int push_promise(struct Curl_cfilter *cf,
+     Curl_set_in_callback(data, false);
+ 
+     /* free the headers again */
+-    for(i = 0; i<stream->push_headers_used; i++)
+-      free(stream->push_headers[i]);
+-    free(stream->push_headers);
+-    stream->push_headers = NULL;
+-    stream->push_headers_used = 0;
++    free_push_headers(stream);
+ 
+     if(rv) {
+       DEBUGASSERT((rv > CURL_PUSH_OK) && (rv <= CURL_PUSH_ERROROUT));
+@@ -1468,14 +1464,14 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
+       if(stream->push_headers_alloc > 1000) {
+         /* this is beyond crazy many headers, bail out */
+         failf(data_s, "Too many PUSH_PROMISE headers");
+-        Curl_safefree(stream->push_headers);
++        free_push_headers(stream);
+         return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+       }
+       stream->push_headers_alloc *= 2;
+-      headp = Curl_saferealloc(stream->push_headers,
+-                               stream->push_headers_alloc * sizeof(char *));
++      headp = realloc(stream->push_headers,
++                      stream->push_headers_alloc * sizeof(char *));
+       if(!headp) {
+-        stream->push_headers = NULL;
++        free_push_headers(stream);
+         return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+       }
+       stream->push_headers = headp;
+-- 
+2.43.0
+

--- a/SOURCES/CVE-2024-2466.patch
+++ b/SOURCES/CVE-2024-2466.patch
@@ -1,0 +1,46 @@
+From 847ae1051b4f12bb46fd22960de30e5492a0ee41 Mon Sep 17 00:00:00 2001
+From: Stefan Eissing <stefan@eissing.org>
+Date: Fri, 15 Mar 2024 10:10:13 +0100
+Subject: [PATCH] mbedtls: fix pytest for newer versions
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Fix the expectations in pytest for newer versions of mbedtls
+
+Closes #13132
+---
+ lib/vtls/mbedtls.c | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+XCP-ng notes: tests/http/test_10_proxy.py and tests/http/testenv/env.py
+removed from source tarball
+
+diff --git a/lib/vtls/mbedtls.c b/lib/vtls/mbedtls.c
+index 7d70de5..8e98b7d 100644
+--- a/lib/vtls/mbedtls.c
++++ b/lib/vtls/mbedtls.c
+@@ -654,14 +654,13 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
+                               &backend->clicert, &backend->pk);
+   }
+ 
+-  if(connssl->peer.sni) {
+-    if(mbedtls_ssl_set_hostname(&backend->ssl, connssl->peer.sni)) {
+-      /* mbedtls_ssl_set_hostname() sets the name to use in CN/SAN checks and
+-         the name to set in the SNI extension. So even if curl connects to a
+-         host specified as an IP address, this function must be used. */
+-      failf(data, "Failed to set SNI");
+-      return CURLE_SSL_CONNECT_ERROR;
+-    }
++  if(mbedtls_ssl_set_hostname(&backend->ssl, connssl->peer.sni?
++                              connssl->peer.sni : connssl->peer.hostname)) {
++    /* mbedtls_ssl_set_hostname() sets the name to use in CN/SAN checks and
++       the name to set in the SNI extension. So even if curl connects to a
++       host specified as an IP address, this function must be used. */
++    failf(data, "Failed to set SNI");
++    return CURLE_SSL_CONNECT_ERROR;
+   }
+ 
+ #ifdef HAS_ALPN
+-- 
+2.43.0
+

--- a/SOURCES/CVE-2024-6197.patch
+++ b/SOURCES/CVE-2024-6197.patch
@@ -1,0 +1,26 @@
+From ab53ed3208c98d7541c6ba4fb0bd498b406ace4f Mon Sep 17 00:00:00 2001
+From: z2_ <88509734+z2-2z@users.noreply.github.com>
+Date: Fri, 28 Jun 2024 14:45:47 +0200
+Subject: [PATCH] x509asn1: remove superfluous free()
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+---
+ lib/vtls/x509asn1.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/lib/vtls/x509asn1.c b/lib/vtls/x509asn1.c
+index da07936..2ccf632 100644
+--- a/lib/vtls/x509asn1.c
++++ b/lib/vtls/x509asn1.c
+@@ -389,7 +389,6 @@ utf8asn1str(struct dynbuf *to, int type, const char *from, const char *end)
+         if(wc >= 0x00000800) {
+           if(wc >= 0x00010000) {
+             if(wc >= 0x00200000) {
+-              free(buf);
+               /* Invalid char. size for target encoding. */
+               return CURLE_WEIRD_SERVER_REPLY;
+             }
+-- 
+2.43.0
+

--- a/SOURCES/CVE-2024-7264-1.patch
+++ b/SOURCES/CVE-2024-7264-1.patch
@@ -1,0 +1,62 @@
+From 8f83b9e92232661f54941658e71de0627f7859f0 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 30 Jul 2024 10:05:17 +0200
+Subject: [PATCH] x509asn1: clean up GTime2str
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Co-authored-by: Stefan Eissing
+Reported-by: Dov Murik
+
+Closes #14307
+---
+ lib/vtls/x509asn1.c | 23 ++++++++++++++---------
+ 1 file changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/lib/vtls/x509asn1.c b/lib/vtls/x509asn1.c
+index 2ccf632..40e2743 100644
+--- a/lib/vtls/x509asn1.c
++++ b/lib/vtls/x509asn1.c
+@@ -488,7 +488,7 @@ static CURLcode GTime2str(struct dynbuf *store,
+   /* Convert an ASN.1 Generalized time to a printable string.
+      Return the dynamically allocated string, or NULL if an error occurs. */
+ 
+-  for(fracp = beg; fracp < end && *fracp >= '0' && *fracp <= '9'; fracp++)
++  for(fracp = beg; fracp < end && ISDIGIT(*fracp); fracp++)
+     ;
+ 
+   /* Get seconds digits. */
+@@ -507,17 +507,22 @@ static CURLcode GTime2str(struct dynbuf *store,
+     return CURLE_BAD_FUNCTION_ARGUMENT;
+   }
+ 
+-  /* Scan for timezone, measure fractional seconds. */
++  /* timezone follows optional fractional seconds. */
+   tzp = fracp;
+-  fracl = 0;
++  fracl = 0; /* no fractional seconds detected so far */
+   if(fracp < end && (*fracp == '.' || *fracp == ',')) {
+-    fracp++;
+-    do
++    /* Have fractional seconds, e.g. "[.,]\d+". How many? */
++    tzp = fracp++; /* should be a digit char or BAD ARGUMENT */
++    while(tzp < end && ISDIGIT(*tzp))
+       tzp++;
+-    while(tzp < end && *tzp >= '0' && *tzp <= '9');
+-    /* Strip leading zeroes in fractional seconds. */
+-    for(fracl = tzp - fracp - 1; fracl && fracp[fracl - 1] == '0'; fracl--)
+-      ;
++    if(tzp == fracp) /* never looped, no digit after [.,] */
++      return CURLE_BAD_FUNCTION_ARGUMENT;
++    fracl = tzp - fracp - 1; /* number of fractional sec digits */
++    DEBUGASSERT(fracl > 0);
++    /* Strip trailing zeroes in fractional seconds.
++     * May reduce fracl to 0 if only '0's are present. */
++    while(fracl && fracp[fracl - 1] == '0')
++      fracl--;
+   }
+ 
+   /* Process timezone. */
+-- 
+2.43.0
+

--- a/SOURCES/CVE-2024-7264-2.patch
+++ b/SOURCES/CVE-2024-7264-2.patch
@@ -1,0 +1,320 @@
+From 680d688685b173bc41fe9d5edaf98428a2d54386 Mon Sep 17 00:00:00 2001
+From: Stefan Eissing <stefan@eissing.org>
+Date: Tue, 30 Jul 2024 16:40:48 +0200
+Subject: [PATCH] x509asn1: unittests and fixes for gtime2str
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Fix issues in GTime2str() and add unit test cases to verify correct
+behaviour.
+
+Follow-up to 3c914bc6801
+
+Closes #14316
+---
+ lib/vtls/x509asn1.c     |  32 +++++++---
+ lib/vtls/x509asn1.h     |  11 ++++
+ tests/data/Makefile.inc |   2 +-
+ tests/data/test1656     |  22 +++++++
+ tests/unit/Makefile.inc |   4 +-
+ tests/unit/unit1656.c   | 133 ++++++++++++++++++++++++++++++++++++++++
+ 6 files changed, 194 insertions(+), 10 deletions(-)
+ create mode 100644 tests/data/test1656
+ create mode 100644 tests/unit/unit1656.c
+
+XCP-ng notes: Patch slightly reworked for tests/data/Makefile.inc and
+tests/unit/Makefile.inc to apply cleanly on top of curl 8.6.0
+
+diff --git a/lib/vtls/x509asn1.c b/lib/vtls/x509asn1.c
+index 40e2743..65dd78a 100644
+--- a/lib/vtls/x509asn1.c
++++ b/lib/vtls/x509asn1.c
+@@ -512,12 +512,13 @@ static CURLcode GTime2str(struct dynbuf *store,
+   fracl = 0; /* no fractional seconds detected so far */
+   if(fracp < end && (*fracp == '.' || *fracp == ',')) {
+     /* Have fractional seconds, e.g. "[.,]\d+". How many? */
+-    tzp = fracp++; /* should be a digit char or BAD ARGUMENT */
++    fracp++; /* should be a digit char or BAD ARGUMENT */
++    tzp = fracp;
+     while(tzp < end && ISDIGIT(*tzp))
+       tzp++;
+     if(tzp == fracp) /* never looped, no digit after [.,] */
+       return CURLE_BAD_FUNCTION_ARGUMENT;
+-    fracl = tzp - fracp - 1; /* number of fractional sec digits */
++    fracl = tzp - fracp; /* number of fractional sec digits */
+     DEBUGASSERT(fracl > 0);
+     /* Strip trailing zeroes in fractional seconds.
+      * May reduce fracl to 0 if only '0's are present. */
+@@ -526,18 +527,24 @@ static CURLcode GTime2str(struct dynbuf *store,
+   }
+ 
+   /* Process timezone. */
+-  if(tzp >= end)
+-    ;           /* Nothing to do. */
++  if(tzp >= end) {
++    tzp = "";
++    tzl = 0;
++  }
+   else if(*tzp == 'Z') {
+-    tzp = " GMT";
+-    end = tzp + 4;
++    sep = " ";
++    tzp = "GMT";
++    tzl = 3;
++  }
++  else if((*tzp == '+') || (*tzp == '-')) {
++    sep = " UTC";
++    tzl = end - tzp;
+   }
+   else {
+     sep = " ";
+-    tzp++;
++    tzl = end - tzp;
+   }
+ 
+-  tzl = end - tzp;
+   return Curl_dyn_addf(store,
+                        "%.4s-%.2s-%.2s %.2s:%.2s:%c%c%s%.*s%s%.*s",
+                        beg, beg + 4, beg + 6,
+@@ -546,6 +553,15 @@ static CURLcode GTime2str(struct dynbuf *store,
+                        sep, (int)tzl, tzp);
+ }
+ 
++#ifdef UNITTESTS
++/* used by unit1656.c */
++CURLcode Curl_x509_GTime2str(struct dynbuf *store,
++                             const char *beg, const char *end)
++{
++  return GTime2str(store, beg, end);
++}
++#endif
++
+ /*
+  * Convert an ASN.1 UTC time to a printable string.
+  *
+diff --git a/lib/vtls/x509asn1.h b/lib/vtls/x509asn1.h
+index 23a67b8..1d8bbab 100644
+--- a/lib/vtls/x509asn1.h
++++ b/lib/vtls/x509asn1.h
+@@ -76,5 +76,16 @@ CURLcode Curl_extract_certinfo(struct Curl_easy *data, int certnum,
+                                const char *beg, const char *end);
+ CURLcode Curl_verifyhost(struct Curl_cfilter *cf, struct Curl_easy *data,
+                          const char *beg, const char *end);
++
++#ifdef UNITTESTS
++#if defined(USE_GNUTLS) || defined(USE_SCHANNEL) || defined(USE_SECTRANSP) || \
++  defined(USE_MBEDTLS)
++
++/* used by unit1656.c */
++CURLcode Curl_x509_GTime2str(struct dynbuf *store,
++                             const char *beg, const char *end);
++#endif
++#endif
++
+ #endif /* USE_GNUTLS or USE_WOLFSSL or USE_SCHANNEL or USE_SECTRANSP */
+ #endif /* HEADER_CURL_X509ASN1_H */
+diff --git a/tests/data/Makefile.inc b/tests/data/Makefile.inc
+index 9b0e808..48bcd4f 100644
+--- a/tests/data/Makefile.inc
++++ b/tests/data/Makefile.inc
+@@ -208,7 +208,7 @@ test1620 test1621 \
+ \
+ test1630 test1631 test1632 test1633 test1634 test1635 \
+ \
+-test1650 test1651 test1652 test1653 test1654 test1655 \
++test1650 test1651 test1652 test1653 test1654 test1655 test1656 \
+ test1660 test1661 test1662 \
+ \
+ test1670 test1671 \
+diff --git a/tests/data/test1656 b/tests/data/test1656
+new file mode 100644
+index 0000000..2fab21b
+--- /dev/null
++++ b/tests/data/test1656
+@@ -0,0 +1,22 @@
++<testcase>
++<info>
++<keywords>
++unittest
++Curl_x509_GTime2str
++</keywords>
++</info>
++
++#
++# Client-side
++<client>
++<server>
++none
++</server>
++<features>
++unittest
++</features>
++<name>
++Curl_x509_GTime2str unit tests
++</name>
++</client>
++</testcase>
+diff --git a/tests/unit/Makefile.inc b/tests/unit/Makefile.inc
+index 36e922b..b0eaf64 100644
+--- a/tests/unit/Makefile.inc
++++ b/tests/unit/Makefile.inc
+@@ -36,7 +36,7 @@ UNITPROGS = unit1300          unit1302 unit1303 unit1304 unit1305 unit1307 \
+  unit1600 unit1601 unit1602 unit1603 unit1604 unit1605 unit1606 unit1607 \
+  unit1608 unit1609 unit1610 unit1611 unit1612 unit1614 \
+  unit1620 unit1621 \
+- unit1650 unit1651 unit1652 unit1653 unit1654 unit1655 \
++ unit1650 unit1651 unit1652 unit1653 unit1654 unit1655 unit1656 \
+  unit1660 unit1661 \
+  unit2600 unit2601 unit2602 unit2603 \
+  unit3200
+@@ -117,6 +117,8 @@ unit1654_SOURCES = unit1654.c $(UNITFILES)
+ 
+ unit1655_SOURCES = unit1655.c $(UNITFILES)
+ 
++unit1656_SOURCES = unit1656.c $(UNITFILES)
++
+ unit1660_SOURCES = unit1660.c $(UNITFILES)
+ 
+ unit1661_SOURCES = unit1661.c $(UNITFILES)
+diff --git a/tests/unit/unit1656.c b/tests/unit/unit1656.c
+new file mode 100644
+index 0000000..644e72f
+--- /dev/null
++++ b/tests/unit/unit1656.c
+@@ -0,0 +1,133 @@
++/***************************************************************************
++ *                                  _   _ ____  _
++ *  Project                     ___| | | |  _ \| |
++ *                             / __| | | | |_) | |
++ *                            | (__| |_| |  _ <| |___
++ *                             \___|\___/|_| \_\_____|
++ *
++ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
++ *
++ * This software is licensed as described in the file COPYING, which
++ * you should have received as part of this distribution. The terms
++ * are also available at https://curl.se/docs/copyright.html.
++ *
++ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
++ * copies of the Software, and permit persons to whom the Software is
++ * furnished to do so, under the terms of the COPYING file.
++ *
++ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
++ * KIND, either express or implied.
++ *
++ * SPDX-License-Identifier: curl
++ *
++ ***************************************************************************/
++#include "curlcheck.h"
++
++#include "vtls/x509asn1.h"
++
++static CURLcode unit_setup(void)
++{
++  return CURLE_OK;
++}
++
++static void unit_stop(void)
++{
++
++}
++
++#if defined(USE_GNUTLS) || defined(USE_SCHANNEL) || defined(USE_SECTRANSP) || \
++  defined(USE_MBEDTLS)
++
++#ifndef ARRAYSIZE
++#define ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))
++#endif
++
++struct test_spec {
++  const char *input;
++  const char *exp_output;
++  CURLcode exp_result;
++};
++
++static struct test_spec test_specs[] = {
++  { "190321134340", "1903-21-13 43:40:00", CURLE_OK },
++  { "", NULL, CURLE_BAD_FUNCTION_ARGUMENT },
++  { "WTF", NULL, CURLE_BAD_FUNCTION_ARGUMENT },
++  { "0WTF", NULL, CURLE_BAD_FUNCTION_ARGUMENT },
++  { "19032113434", NULL, CURLE_BAD_FUNCTION_ARGUMENT },
++  { "19032113434WTF", NULL, CURLE_BAD_FUNCTION_ARGUMENT },
++  { "190321134340.", NULL, CURLE_BAD_FUNCTION_ARGUMENT },
++  { "190321134340.1", "1903-21-13 43:40:00.1", CURLE_OK },
++  { "19032113434017.0", "1903-21-13 43:40:17", CURLE_OK },
++  { "19032113434017.01", "1903-21-13 43:40:17.01", CURLE_OK },
++  { "19032113434003.001", "1903-21-13 43:40:03.001", CURLE_OK },
++  { "19032113434003.090", "1903-21-13 43:40:03.09", CURLE_OK },
++  { "190321134340Z", "1903-21-13 43:40:00 GMT", CURLE_OK },
++  { "19032113434017.0Z", "1903-21-13 43:40:17 GMT", CURLE_OK },
++  { "19032113434017.01Z", "1903-21-13 43:40:17.01 GMT", CURLE_OK },
++  { "19032113434003.001Z", "1903-21-13 43:40:03.001 GMT", CURLE_OK },
++  { "19032113434003.090Z", "1903-21-13 43:40:03.09 GMT", CURLE_OK },
++  { "190321134340CET", "1903-21-13 43:40:00 CET", CURLE_OK },
++  { "19032113434017.0CET", "1903-21-13 43:40:17 CET", CURLE_OK },
++  { "19032113434017.01CET", "1903-21-13 43:40:17.01 CET", CURLE_OK },
++  { "190321134340+02:30", "1903-21-13 43:40:00 UTC+02:30", CURLE_OK },
++  { "19032113434017.0+02:30", "1903-21-13 43:40:17 UTC+02:30", CURLE_OK },
++  { "19032113434017.01+02:30", "1903-21-13 43:40:17.01 UTC+02:30", CURLE_OK },
++  { "190321134340-3", "1903-21-13 43:40:00 UTC-3", CURLE_OK },
++  { "19032113434017.0-04", "1903-21-13 43:40:17 UTC-04", CURLE_OK },
++  { "19032113434017.01-01:10", "1903-21-13 43:40:17.01 UTC-01:10", CURLE_OK },
++};
++
++static bool do_test(struct test_spec *spec, size_t i, struct dynbuf *dbuf)
++{
++  CURLcode result;
++  const char *in = spec->input;
++
++  Curl_dyn_reset(dbuf);
++  result = Curl_x509_GTime2str(dbuf, in, in + strlen(in));
++  if(result != spec->exp_result) {
++    fprintf(stderr, "test %zu: expect result %d, got %d\n",
++            i, spec->exp_result, result);
++    return FALSE;
++  }
++  else if(!result && strcmp(spec->exp_output, Curl_dyn_ptr(dbuf))) {
++    fprintf(stderr, "test %zu: input '%s', expected output '%s', got '%s'\n",
++            i, in, spec->exp_output, Curl_dyn_ptr(dbuf));
++    return FALSE;
++  }
++
++  return TRUE;
++}
++
++UNITTEST_START
++{
++  size_t i;
++  struct dynbuf dbuf;
++  bool all_ok = TRUE;
++
++  Curl_dyn_init(&dbuf, 32*1024);
++
++  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
++    fprintf(stderr, "curl_global_init() failed\n");
++    return TEST_ERR_MAJOR_BAD;
++  }
++
++  for(i = 0; i < ARRAYSIZE(test_specs); ++i) {
++    if(!do_test(&test_specs[i], i, &dbuf))
++      all_ok = FALSE;
++  }
++  fail_unless(all_ok, "some tests of Curl_x509_GTime2str() fails");
++
++  Curl_dyn_free(&dbuf);
++  curl_global_cleanup();
++}
++UNITTEST_STOP
++
++#else
++
++UNITTEST_START
++{
++  puts("not tested since Curl_x509_GTime2str() is not built-in");
++}
++UNITTEST_STOP
++
++#endif
+-- 
+2.43.0
+

--- a/SPECS/curl.spec
+++ b/SPECS/curl.spec
@@ -5,7 +5,7 @@
 Summary: A utility for getting files from remote servers (FTP, HTTP, and others)
 Name: curl
 Version: 8.6.0
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: MIT
 Source0: curl-8.6.0.tar.xz
 Patch0: 0001-curl-8.6.0-remove-duplicate-content.patch
@@ -18,6 +18,15 @@ Patch6: 0104-curl-7.88.0-tests-warnings.patch
 Patch7: 0200-curl-8.6.0-ntml_wb-fix-buffer-type-typo.patch
 Patch8: 0300-curl-8.6.0-nss-compat.patch
 Patch9: 0301-curl-8.6.0-tests.patch
+
+# XCP-ng specific patches
+Patch1000: CVE-2024-2004.patch
+Patch1001: CVE-2024-2379.patch
+Patch1002: CVE-2024-2398.patch
+Patch1003: CVE-2024-2466.patch
+Patch1004: CVE-2024-6197.patch
+Patch1005: CVE-2024-7264-1.patch
+Patch1006: CVE-2024-7264-2.patch
 
 Provides: curl-full = %{version}-%{release}
 Provides: webclient
@@ -339,6 +348,9 @@ rm -f ${RPM_BUILD_ROOT}%{_mandir}/man1/mk-ca-bundle.1*
 %{_datadir}/aclocal/libcurl.m4
 
 %changelog
+* Wed Aug 07 2024 Thierry Escande <thierry.escande@vates.tech> - 8.6.0-2.2
+- Backported CVEs 2024-2004, 2024-2379, 2024-2398, 2024-2466, 2024-6197, and 2024-7264
+
 * Wed May 31 2024 Gael Duperrey <gduperrey@vates.tech> - 8.6.0-2.1
 - Synced from curl-8.6.0-2.xs8.src.rpm
 - Removed xenserver-specific test of the dist macro


### PR DESCRIPTION
This change backports CVEs 2024-2004, 2024-2379, 2024-2398, 2024-2466, 2024-6197, and 2024-7264.